### PR TITLE
Replace deprected curly braces for offset access

### DIFF
--- a/plugin/src/rules/Revisions.php
+++ b/plugin/src/rules/Revisions.php
@@ -22,7 +22,7 @@ class Revisions {
 	public function filterMeta( $meta ): array {
 		$metaFiltered = [];
 		foreach ( $meta as $key => $value ) {
-			if ( $key{0} != "_" ) {
+			if ( $key[0] != "_" ) {
 				$metaFiltered[ $key ] = $value;
 			}
 		}


### PR DESCRIPTION
Deprecated in PHP7, removed in PHP8.

This is the only instance I was able to find by a quick search